### PR TITLE
Update Resource to work with resource.data

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.1.1",
   "dependencies": {
-    "@civicactions/data-catalog-components": "0.1.8",
+    "@civicactions/data-catalog-components": "0.1.9",
     "@cmsgov/design-system-core": "^3.0.0",
     "@fortawesome/fontawesome-svg-core": "^1.2.25",
     "@fortawesome/free-brands-svg-icons": "^5.11.2",

--- a/src/components/Resource/DatatableHeader/index.js
+++ b/src/components/Resource/DatatableHeader/index.js
@@ -6,7 +6,6 @@ import {
   ResourceDispatch,
   DataIcon
 } from "@civicactions/data-catalog-components";
-//import DataIcon from '../../DataIcon';
 import FullScreenResource from "../FullScreenResource";
 import ManageColumns from "../ManageColumns";
 
@@ -56,8 +55,8 @@ const DatatableHeader = ({ fullscreen }) => {
                     icon="density-1"
                     name="density-1"
                     fill="#666666"
-                    height="20"
-                    width="20"
+                    height={20}
+                    width={20}
                   />
                 ),
                 text: "expanded",
@@ -69,8 +68,8 @@ const DatatableHeader = ({ fullscreen }) => {
                     icon="density-2"
                     name="density-2"
                     fill="#666666"
-                    height="20"
-                    width="20"
+                    height={20}
+                    width={20}
                   />
                 ),
                 text: "normal",
@@ -82,8 +81,8 @@ const DatatableHeader = ({ fullscreen }) => {
                     icon="density-3"
                     name="density-3"
                     fill="#666666"
-                    height="20"
-                    width="20"
+                    height={20}
+                    width={20}
                   />
                 ),
                 text: "tight",
@@ -93,7 +92,7 @@ const DatatableHeader = ({ fullscreen }) => {
           />
         </div>
         <ManageColumns />
-        {!fullscreen && <FullScreenResource />}
+        {/* {!fullscreen && <FullScreenResource />} */}
       </div>
     </div>
   );

--- a/src/components/Resource/index.js
+++ b/src/components/Resource/index.js
@@ -69,7 +69,6 @@ const Resource = ({ resource, identifier }) => {
   const totalResults = resourceState.filters.length ? resourceState.count : resourceState.rowsTotal;
   const pages = Math.ceil(parseInt(totalResults, 10) / resourceState.pageSize);
   const preview = ["csv", "CSV", "text/csv"];
-  console.log(resourceState.values, preview.includes(format), resourceState.store)
   if (resourceState.values && preview.includes(format) ) {}
     return (
       <ResourceDispatch.Provider value={{ resourceState, dispatch }}>

--- a/src/components/Resource/index.js
+++ b/src/components/Resource/index.js
@@ -19,11 +19,11 @@ const Resource = ({ resource, identifier }) => {
   // File Format.
   const type = resource.hasOwnProperty('mediaType') ? resource.mediaType.split('/') : '';
   const backup = type ? type[1] : 'unknown';
-  const format = resource.hasOwnProperty('format') ? resource.format : backup;
+  const format = resource.data.hasOwnProperty('format') ? resource.data.format : backup;
   // File Url.
-  const accessURL = resource.hasOwnProperty('accessURL') ? resource.accessURL : '';
-  const fileURL = resource.hasOwnProperty('downloadURL') ? resource.downloadURL : accessURL;
-  const title = resource.hasOwnProperty('title') ? resource.title : format;
+  const accessURL = resource.data.hasOwnProperty('accessURL') ? resource.accessURL : '';
+  const fileURL = resource.data.hasOwnProperty('downloadURL') ? resource.data.downloadURL : accessURL;
+  const title = resource.data.hasOwnProperty('title') ? resource.data.title : format;
   const rootURL = `${process.env.DYNAMIC_API_URL}/`;
   const [resourceState, dispatch] = React.useReducer(
     resourceReducer,
@@ -60,7 +60,7 @@ const Resource = ({ resource, identifier }) => {
     resourceState.pageSize,
     resourceState.sort
   ]);
-  const dataKey = identifier;
+  const dataKey = resource.identifier ? resource.identifier : identifier;
   const advTableColumns = advancedColumns(
     resourceState.columns,
     resourceState.columnOrder,
@@ -69,6 +69,7 @@ const Resource = ({ resource, identifier }) => {
   const totalResults = resourceState.filters.length ? resourceState.count : resourceState.rowsTotal;
   const pages = Math.ceil(parseInt(totalResults, 10) / resourceState.pageSize);
   const preview = ["csv", "CSV", "text/csv"];
+  console.log(resourceState.values, preview.includes(format), resourceState.store)
   if (resourceState.values && preview.includes(format) ) {}
     return (
       <ResourceDispatch.Provider value={{ resourceState, dispatch }}>

--- a/src/templates/dataset/index.jsx
+++ b/src/templates/dataset/index.jsx
@@ -9,6 +9,7 @@ import {
   Tags
 } from "@civicactions/data-catalog-components";
 import orgs from "../../assets/publishers";
+import Resource from '../../components/Resource';
 
 const Dataset = props => {
   const item = props.pageContext.dataset;
@@ -119,10 +120,10 @@ const Dataset = props => {
             <h1>{item.title}</h1>
             {theme.length && <div className="item-theme">{themes(theme)}</div>}
             <Text value={item.description} />
-            {/* {hasWindow &&
+            {hasWindow &&
               item.distribution.map(dist => {
-                return <Resource resource={dist.data} identifier={1} />;
-              })} */}
+                return <Resource resource={dist} key={dist.identifier} identifier={1} />;
+              })}
             <Tags tags={tag} path="/search?keyword=" label="Tags" />
             {/* <Table
               configuration={labelsT2}

--- a/src/theme/styles/index.scss
+++ b/src/theme/styles/index.scss
@@ -3,6 +3,7 @@
 @import "./general.scss";
 
 // Component styles.
+@import "../../components/Resource/DatatableHeader/datatableheader.scss";
 
 // Template styles.
 @import "../../templates/FeaturedDatasets/featureddatasets.scss";


### PR DESCRIPTION
This PR re-enables the frontend housed Resource component by updating props. It uses the new DataIcon export from data-catalog-components. It also added the DataTableHeader scss file to the build. 