### PR TITLE
Lock swagger-ui to 3.25.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "data-catalog-frontend",
   "private": true,
-  "version": "0.1.1",
+  "version": "0.1.2",
   "dependencies": {
     "@civicactions/data-catalog-components": "0.1.9",
     "@cmsgov/design-system-core": "^3.0.0",
@@ -47,7 +47,7 @@
     "react-spinjs": "^3.0.0",
     "react-table": "^6.10.0",
     "styled-components": "^4.3.2",
-    "swagger-ui-react": "^3.23.6"
+    "swagger-ui-react": "3.25.0"
   },
   "devDependencies": {
     "prettier": "^1.18.2"


### PR DESCRIPTION
Fix api pages by locking swagger-ui-react