### PR TITLE
Remove data table from loading if format is not csv

### DIFF
--- a/cypress/integration/dataset.spec.js
+++ b/cypress/integration/dataset.spec.js
@@ -1,10 +1,10 @@
 context('Dataset', () => {
-
+  const rootURL = 'http://dkan'
   const table1 = '#resource_e4854391-e248-5eca-88ce-7b41d3bc02da';
   const table2 = '#resource_eed01862-e6c0-5aa6-8c2b-91cca5108ed3';
 
   beforeEach(() => {
-    cy.visit("http://dkan/dataset/1f2042ad-c513-4fcf-a933-cae6c6fd35e6")
+    cy.visit(`${rootURL}/dataset/1f2042ad-c513-4fcf-a933-cae6c6fd35e6`)
   })
 
   it('I see the title and description', () => {
@@ -172,5 +172,11 @@ context('Dataset', () => {
     cy.get(`#dc-modal-manage_columns-close`).click()
     cy.get(`${table1} .dc-table:first-of-type > :nth-child(1) > .tr > :nth-child(1)`).should('contain', 'record_number')
     cy.get(`${table2} .dc-table:first-of-type > :nth-child(1) .tr > :nth-child(1)`).should('contain', 'state_abbreviation')
+  })
+
+  it.only('I don\'t see a datatable if a distribution doesn\'t contain a csv file.', () => {
+    cy.visit(`${rootURL}/dataset/fb3525f2-d32a-451e-8869-906ed41f7695`)
+    cy.wait(6000)
+    cy.get(`.dc-datatable`).should('not.exist');
   })
 })

--- a/src/components/Resource/index.js
+++ b/src/components/Resource/index.js
@@ -11,21 +11,33 @@ const ResourceTemplate = ({ resource }) => {
   const rootURL = `${process.env.DYNAMIC_API_URL}/`;
   return (
     <div id={`resource_${resource.identifier}`}>
-      <Resource
-        apiURL={rootURL}
-        identifier={resource.identifier}
-        resource={resource}
-        showDBColumnNames={true}
-      >
-        <FileDownload
-          title={resource.data.title}
-          label={resource.data.downloadURL}
-          format={format}
-          downloadURL={resource.data.downloadURL}
-        />
-        <DataTableHeader />
-        <DataTable />
-      </Resource>
+      {format.toLowerCase() === 'csv'
+        ? (
+          <Resource
+            apiURL={rootURL}
+            identifier={resource.identifier}
+            resource={resource}
+            showDBColumnNames={true}
+          >
+            <FileDownload
+              title={resource.data.title}
+              label={resource.data.downloadURL}
+              format={format}
+              downloadURL={resource.data.downloadURL}
+            />
+            <DataTableHeader />
+            <DataTable />
+          </Resource>
+        )
+        : (
+          <FileDownload
+            title={resource.data.title}
+            label={resource.data.downloadURL}
+            format={format}
+            downloadURL={resource.data.downloadURL}
+          />
+        )
+      }
     </div>
   );
 };


### PR DESCRIPTION
Add conditional check for format before loading the datatable/datatable-header on dataset pages.
Includes new test for dataset that has only zip file to make sure datatable doesn't load.

Fixes #33 