### PR TITLE
Allow dataset page to display without defined org image

### DIFF
--- a/cypress/integration/dataset.spec.js
+++ b/cypress/integration/dataset.spec.js
@@ -89,6 +89,7 @@ context('Dataset', () => {
     cy.get(`${table2} .page-size-select`).select('50')
     cy.get(`${table2} .-pageInfo`).should('contain', 'Page 1 of 2')
     cy.get(`${table2} .page-size-select`).select('100')
+    cy.wait(6000)
     cy.get(`${table2} .-pageInfo`).should('contain', 'Page 1 of 1')
   })
 

--- a/cypress/integration/home.spec.js
+++ b/cypress/integration/home.spec.js
@@ -32,7 +32,7 @@ beforeEach(() => {
     cy.viewport('macbook-13')
   })
 
-  it.skip('When I click the main menu Publishers link I should end up on the Publishers page', () => {
+  it('When I click the main menu Publishers link I should end up on the Publishers page', () => {
     cy.get('.navbar .nav').contains('Publishers').click({ force: true })
     cy.wait(5000)
     cy.get('h1').contains('Dataset Publishers')

--- a/cypress/integration/home.spec.js
+++ b/cypress/integration/home.spec.js
@@ -32,12 +32,6 @@ beforeEach(() => {
     cy.viewport('macbook-13')
   })
 
-  it('When I click the main menu Publishers link I should end up on the Publishers page', () => {
-    cy.get('.navbar .nav').contains('Publishers').click({ force: true })
-    cy.wait(5000)
-    cy.get('h1').contains('Dataset Publishers')
-  })
-
   it('I should see the expected custom text on the home page', () => {
     cy.get('.dc-hero-title').should('contain', 'Welcome to DKAN');
     cy.get('.dc-hero-search button').should('contain', 'Go');

--- a/cypress/integration/publishers.spec.js
+++ b/cypress/integration/publishers.spec.js
@@ -1,0 +1,14 @@
+context('Publishers', () => {
+
+  beforeEach(() => {
+      cy.visit("http://dkan/home")
+    })
+
+    it.only('When I click the main menu Publishers link I should end up on the Publishers page', () => {
+      cy.get('.navbar .nav').contains('Publishers').click({ force: true })
+      cy.wait(5000)
+      cy.get('h1').contains('Dataset Publishers')
+      cy.get('.dc-publisher-list > :nth-child(1) > a > img').should('have.attr', 'src').should('include','group.png')
+    })
+
+  })

--- a/src/assets/publishers.json
+++ b/src/assets/publishers.json
@@ -1,7 +1,6 @@
 [
   {
     "name": "State Economic Council",
-    "imageUrl": "https://dkan-default-content-files.s3.amazonaws.com/files/publishers/money-saving.png",
     "description": "The State Economic Council is responsible for increasing economic development of the state by collecting statistics and performing analysis on the labor force, workforce and employer demographics, generational trends, etc."
   },
   {

--- a/src/templates/dataset/index.jsx
+++ b/src/templates/dataset/index.jsx
@@ -28,8 +28,14 @@ const Dataset = props => {
   const orgName =
     "publisher" in item && item.publisher ? item.publisher.data.name : "";
   const orgDetails = orgs.filter(org => orgName === org.name);
-  const orgImage = orgDetails && orgDetails[0].imageUrl ? orgDetails[0].imageUrl : "";
-  const orgDesc = orgDetails && orgDetails[0].description ? orgDetails[0].description : "";
+  const orgImage = orgDetails.length > 0 && orgDetails[0].imageUrl ? orgDetails[0].imageUrl : null;
+  const orgDesc = orgDetails.length > 0 && orgDetails[0].description ? orgDetails[0].description : "";
+  let renderOrg;
+  if(orgDetails.length > 0 && orgDetails[0].imageUrl) {
+    renderOrg = <Organization name={orgName} imageUrl={orgImage} description={orgDesc}/>;
+  } else {
+    renderOrg = <Organization name={orgName} description={orgDesc}/>;
+  }
 
   const tag = "keyword" in item ? item.keyword : [];
   const theme = "theme" in item ? item.theme : [];
@@ -102,11 +108,7 @@ const Dataset = props => {
       <div className={`dc-dataset-page ${config.container}`}>
         <div className="row">
           <div className="col-md-3 col-sm-12">
-            <Organization
-              name={orgName}
-              imageUrl={orgImage}
-              description={orgDesc}
-            />
+            {renderOrg}
             <div className="dc-block-wrapper">
               The information on this page is also available via the{" "}
               <Link to={`dataset/${item.identifier}/api`}>API</Link>.


### PR DESCRIPTION
Avoid `error  'imageUrl' is not defined` on dataset pages when publisher image is not available.

## QA steps
1. Edit the assets/publishers.json file to remove the imageURL value from one or all of the publishers.
2. rebuild the front end
3. go to a dataset page for that publisher and confirm the page renders with the generic publisher image