### PR TITLE
Allow dataset page to build even if missing distributions

### DIFF
--- a/src/templates/dataset/index.jsx
+++ b/src/templates/dataset/index.jsx
@@ -118,7 +118,7 @@ const Dataset = props => {
             <h1>{item.title}</h1>
             {theme.length && <div className="dc-item-theme">{themes(theme)}</div>}
             <Text value={item.description} />
-            {hasWindow &&
+            {hasWindow && item.distribution &&
               item.distribution.map(dist => {
                 return <ResourceTemplate key={dist.identifier} resource={dist} identifier={dist.identifier} />;
               })}


### PR DESCRIPTION
Let's not crash the dataset if it does not have a distribution

```
TypeError: Cannot read property 'map' of undefined
```