### PR TITLE
Check for length greater than 0 on template render

### DIFF
--- a/src/templates/dataset/index.jsx
+++ b/src/templates/dataset/index.jsx
@@ -116,7 +116,7 @@ const Dataset = props => {
           </div>
           <div className="col-md-9 col-sm-12">
             <h1>{item.title}</h1>
-            {theme.length && <div className="dc-item-theme">{themes(theme)}</div>}
+            {theme.length > 0 && <div className="dc-item-theme">{themes(theme)}</div>}
             <Text value={item.description} />
             {hasWindow && item.distribution &&
               item.distribution.map(dist => {


### PR DESCRIPTION
When no themes are available, a 0 renders instead of nothing. This update just changes the check to make sure there are items in the array since an array of 0 still has a length. Fixes one part of https://github.com/GetDKAN/data-catalog-components/issues/81