### PR TITLE
Use baseUrl from cypress config instead of hardcoded path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,6 +51,7 @@ jobs:
           command: |
             export PATH=$PATH:~/dkan-tools/bin
             cd ~/sandbox
+            dktl dc up -d
             dktl dc exec web chmod -R 777 /var/www/docroot/data-catalog-frontend
             dktl drush user:create testuser --password="2jqzOAnXS9mmcLasy"
             dktl drush en sample_content frontend -y

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
           name: Install DKTL
           command: |
             cd ~
-            git clone --single-branch --depth 1 https://github.com/GetDKAN/dkan-tools.git
+            git clone --branch=improvements --single-branch --depth 1 https://github.com/GetDKAN/dkan-tools.git
             chmod 777 ./dkan-tools/bin/dktl
             export PATH=$PATH:~/dkan-tools/bin
             which dktl

--- a/cypress/integration/dataset.spec.js
+++ b/cypress/integration/dataset.spec.js
@@ -2,6 +2,8 @@ context('Dataset', () => {
   const table1 = '#resource_e4854391-e248-5eca-88ce-7b41d3bc02da';
   const table2 = '#resource_eed01862-e6c0-5aa6-8c2b-91cca5108ed3';
 
+  let baseUrl = Cypress.config().baseUrl;
+
   beforeEach(() => {
     cy.visit('dataset/1f2042ad-c513-4fcf-a933-cae6c6fd35e6')
   })
@@ -13,8 +15,8 @@ context('Dataset', () => {
 
   it('I see the file is available to download for each dataset', () => {
     cy.get('.dc-resource:first-of-type > svg').should('have.attr', 'class', 'dkan-icon')
-    cy.get(`${table1} .dc-resource > a`).should('have.attr', 'href', 'http://dkan/sites/default/files/distribution/1f2042ad-c513-4fcf-a933-cae6c6fd35e6/TobaccoTaxes2016_2_1.csv');
-    cy.get(`${table2} .dc-resource > a`).should('have.attr', 'href', 'http://dkan/sites/default/files/distribution/1f2042ad-c513-4fcf-a933-cae6c6fd35e6/CDCSmokingRates.csv');
+    cy.get(`${table1} .dc-resource > a`).should('have.attr', 'href', baseUrl + '/sites/default/files/distribution/1f2042ad-c513-4fcf-a933-cae6c6fd35e6/TobaccoTaxes2016_2_1.csv');
+    cy.get(`${table2} .dc-resource > a`).should('have.attr', 'href', baseUrl + '/sites/default/files/distribution/1f2042ad-c513-4fcf-a933-cae6c6fd35e6/CDCSmokingRates.csv');
   })
 
   // add check to make sure message updates to correct amount of rows

--- a/cypress/integration/publishers.spec.js
+++ b/cypress/integration/publishers.spec.js
@@ -1,7 +1,9 @@
 context('Publishers', () => {
 
+  let baseUrl = Cypress.config().baseUrl;
+
   beforeEach(() => {
-      cy.visit("http://dkan/home")
+      cy.visit(baseUrl + "/home")
     })
 
     it.only('When I click the main menu Publishers link I should end up on the Publishers page', () => {


### PR DESCRIPTION
Some cypress tests have some hard-coded `http://dkan` paths which made sense at the time. Substitute those with `Cypress.config().baseUrl` to be able to override those in various scenarios.