### PR TITLE
Fix Circle CI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
           command: |
             export PATH=$PATH:~/dkan-tools/bin
             cd ~/sandbox
-            dktl get 8.8.5
+            dktl get 8.9.0
       - run:
           name: Make DKAN
           command: |
@@ -45,7 +45,7 @@ jobs:
           command: |
             export PATH=$PATH:~/dkan-tools/bin
             cd ~/sandbox
-            dktl install
+            dktl install --demo
       - run:
           name: Run cypress tests
           command: |
@@ -53,11 +53,6 @@ jobs:
             cd ~/sandbox
             dktl dc exec web chmod -R 777 /var/www/docroot/data-catalog-frontend
             dktl drush user:create testuser --password="2jqzOAnXS9mmcLasy"
-            dktl drush en sample_content frontend -y
-            dktl drush dkan:sample-content:create
-            dktl drush queue:run datastore_import
-            dktl drush dkan:metastore-search:rebuild-tracker
-            dktl drush search-api-index
             dktl frontend:install
             dktl frontend:build
             dktl dc exec web chmod -R 777 /var/www/docroot/sites/default/files/dkan-tmp


### PR DESCRIPTION
Currently the Gatsby site can't build on Circle CI. This PR attempts to address the issue and fix CI builds. 